### PR TITLE
A couple of improvements to the product view

### DIFF
--- a/DTOs/ProductOverviewDTO.cs
+++ b/DTOs/ProductOverviewDTO.cs
@@ -1,0 +1,11 @@
+namespace Pharmatic.DTOs;
+
+public class ProductOverviewDto
+{
+    public int ProductNo { get; set; }
+    public string ProductName { get; set; } = default!;
+    public string CategoryName { get; set; } = default!;
+    public string? ImageUrl { get; set; }
+    public int LotCount { get; set; }
+    public List<string> ProductTags { get; set; } = default!;
+}

--- a/Pages/Products.razor
+++ b/Pages/Products.razor
@@ -29,32 +29,26 @@
         @foreach (var prod in product_list)
         {
             <MudItem xl="4" lg="6" sm="6" xs="12">
-                <a href="/productos/detalle/@prod.productNo">
+                <a href="/productos/detalle/@prod.ProductNo">
                     <MudGrid Style="outline: 1px solid #E6E6E6; border-radius:24px;" Class="hover-card">
-                    
-
-                        <MudItem xs="4">
-                            <MudImage Src="@prod.imageUrl" Width="80" Height="80" Elevation="25" Class="rounded-lg ma-2" />
+                        <MudItem xs="3">
+                            <MudImage Fluid="true" ObjectFit="ObjectFit.ScaleDown" ObjectPosition="ObjectPosition.Center" Src="@prod.ImageUrl" Elevation="25" Class="rounded-lg ma-2" />
                         </MudItem>
                         
-                        <MudItem xs="8">
-                            <MudText Typo="Typo.body1" Style="font-weight:bolder;">@prod.name</MudText>
-                            <MudText Typo="Typo.body2">@prod.category?.name - # de lotes @prod.lotCount</MudText>
-                            @if (prod.tags?.Count > 0)
+                        <MudItem xs="7" Class="justify-center">
+                            <MudText Typo="Typo.body1" Style="font-weight:bolder;">@prod.ProductName</MudText>
+                            <MudText Typo="Typo.body2">@prod.CategoryName</MudText>
+                            @foreach (var tag in prod.ProductTags)
                             {
-                                @foreach (var tag in prod.tags)
-                                {
-                                    <MudChip Color="Color.Primary" Size="Size.Small">@tag.name</MudChip>
-                                }
-                            }
-                            else
-                            {
-                                <MudChip Color="Color.Error" Size="Size.Small">Sin etiquetas</MudChip>
-
+                                <MudChip Color="Color.Primary" Size="Size.Small">@tag</MudChip>
                             }
                         </MudItem>
-                    
-                </MudGrid>
+
+                        <MudItem xs="2" Class="d-flex align-start gap-1">
+                            <MudText Typo="Typo.body1" Style="font-weight:bolder;">@prod.LotCount</MudText>
+                            <MudIcon Icon="@Icons.Material.Filled.Inventory" Color=@(prod.LotCount > 0 ? Color.Inherit : Color.Warning) Size="Size.Medium"/>
+                        </MudItem>
+                    </MudGrid>
                 </a>
 
             </MudItem>
@@ -65,7 +59,7 @@
 
 @code {
     private string search_text = string.Empty;
-    private List<ProductDTO> product_list = new List<ProductDTO>();
+    private List<ProductOverviewDto> product_list = new ();
 
     protected override async Task OnInitializedAsync()
     {
@@ -84,7 +78,7 @@
 
     private async Task GetProducts()
     {
-        var result = await _productService.ProductList();
+        var result = await _productService.ProductsOverview();
         product_list = result!;
     }
 

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -32,6 +32,14 @@ namespace Pharmatic.Services
             return result!;
         }
 
+        public async Task<List<ProductOverviewDto>> ProductsOverview()
+        {
+            var url = $"http://localhost:{port}/api/products/overview";
+            await SetTokenAsync();
+            var result = await _http.GetFromJsonAsync<List<ProductOverviewDto>>(url);
+            return result!;
+        }
+
         public async Task<ProductDTO> SearchProduct(string id)
         {
             var url = $"http://localhost:{port}/api/products/" + id;


### PR DESCRIPTION
- Mejor escalado de imágenes
- Estilo material para el conteo de lotes
- Rendimiento casi instantáneo al usar el endpoint `api/products/overview`

### Antes

https://github.com/HKM-UNI/Pharmatic-MudBlazor/assets/82670759/8c0e9bd3-054c-4dfe-9b50-4cf46f752aca

### Despues

https://github.com/HKM-UNI/Pharmatic-MudBlazor/assets/82670759/e35a3fed-e2b0-4029-b43a-796245502719

